### PR TITLE
Adds dependencies to REQUIRE file

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,5 @@
 julia 0.7
+ImageCore
+ColorTypes
+ColorVectorSpace
+FixedPointNumbers


### PR DESCRIPTION
Fixes an oversight that prevents the package from compiling. I had originally added the dependencies to Project.toml but forgot to add them to the REQUIRE file as well.