### PR TITLE
Relaxes minimum Julia dependency from version 1.1 to  1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
   - windows
 julia:
-  - 1.1.0
+  - 1.0
   - 1
   - nightly
 matrix:

--- a/Project.toml
+++ b/Project.toml
@@ -1,20 +1,24 @@
 name = "ImageContrastAdjustment"
 uuid = "f332f351-ec65-5f6a-b3d1-319c6670881a"
 authors = ["Dr. Zygmunt L. Szpak <zygmunt.szpak@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
 MappedArrays = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"
+Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 
 [compat]
 ColorVectorSpace = "0.6, 0.7, 0.8"
+Compat = "2.1.0, 3"
 ImageCore = "0.8.5"
 ImageTransformations = "0.8.1"
 MappedArrays = "0.2.2"
-julia = "1.1"
+Parameters = "0.12"
+julia = "1"
 
 [extras]
 ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"

--- a/src/ImageContrastAdjustment.jl
+++ b/src/ImageContrastAdjustment.jl
@@ -1,9 +1,11 @@
 module ImageContrastAdjustment
 
 using ColorVectorSpace
+using Compat: @compat, isnothing
 using ImageCore
 using ImageTransformations: imresize
 using MappedArrays
+using Parameters: @with_kw # Same as Base.@kwdef but works on Julia 1.0
 
 # TODO: port HistogramAdjustmentAPI to ImagesAPI
 include("HistogramAdjustmentAPI/HistogramAdjustmentAPI.jl")

--- a/src/algorithms/adaptive_equalization.jl
+++ b/src/algorithms/adaptive_equalization.jl
@@ -239,7 +239,7 @@ imshow(imgeq)
 2. S. M. Pizer, E. P. Amburn, J. D. Austin, R. Cromartie, A. Geselowitz, T. Greer, B. ter Haar Romeny, J. B. Zimmerman and K. Zuiderveld “Adaptive histogram equalization and its variations,” *Computer Vision, Graphics, and Image Processing*, vol. 38, no. 1, p. 99, Apr. 1987. [10.1016/S0734-189X(87)80186-X](https://doi.org/10.1016/s0734-189x(87)80156-1)
 3. W. H. Press, S. A. Teukolsky, W. T. Vetterling, and B. P. Flannery.  *Numerical Recipes: The Art of Scientific Computing (3rd Edition)*. New York, NY, USA: Cambridge University Press, 2007.
 """
-Base.@kwdef struct AdaptiveEqualization{T₁ <: Union{Real,AbstractGray},
+@with_kw struct AdaptiveEqualization{T₁ <: Union{Real,AbstractGray},
                                         T₂ <: Union{Real,AbstractGray},
                                         T₃ <: Real} <: AbstractHistogramAdjustmentAlgorithm
     nbins::Int = 256

--- a/src/algorithms/contrast_stretching.jl
+++ b/src/algorithms/contrast_stretching.jl
@@ -62,7 +62,7 @@ ret = adjust_histogram(img, ContrastStretching(t = 0.6, slope = 3))
 1. Gonzalez, R. C., Woods, R. E., & Eddins, S. L. (2004). *Digital image processing using MATLAB* (Vol. 624). Upper Saddle River, New Jersey: Pearson-Prentice-Hall.
 
 """
-Base.@kwdef struct ContrastStretching{T₁ <: Union{Real,AbstractGray},
+@with_kw struct ContrastStretching{T₁ <: Union{Real,AbstractGray},
                                       T₂ <: Union{Real,AbstractGray}}  <: AbstractHistogramAdjustmentAlgorithm
      t::T₁ = 0.5
      slope::T₂ = 1.0

--- a/src/algorithms/equalization.jl
+++ b/src/algorithms/equalization.jl
@@ -96,7 +96,7 @@ imshow(imgeq)
 # References
 1. R. C. Gonzalez and R. E. Woods. *Digital Image Processing (3rd Edition)*.  Upper Saddle River, NJ, USA: Prentice-Hall,  2006.
 """
-Base.@kwdef struct Equalization{T₁ <: Union{Real,AbstractGray},
+@with_kw struct Equalization{T₁ <: Union{Real,AbstractGray},
                                 T₂ <: Union{Real,AbstractGray}} <: AbstractHistogramAdjustmentAlgorithm
     nbins::Int = 256
     minval::T₁ = 0.0

--- a/src/algorithms/gamma_correction.jl
+++ b/src/algorithms/gamma_correction.jl
@@ -75,7 +75,7 @@ imshow(imgadj)
 # References
 1. W. Burger and M. J. Burge. *Digital Image Processing*. Texts in Computer Science, 2016. [doi:10.1007/978-1-4471-6684-9](https://doi.org/10.1007/978-1-4471-6684-9)
 """
-Base.@kwdef struct GammaCorrection{T <: Real} <: AbstractHistogramAdjustmentAlgorithm
+@with_kw struct GammaCorrection{T <: Real} <: AbstractHistogramAdjustmentAlgorithm
     gamma::T = 1.0
 end
 

--- a/src/algorithms/linear_stretching.jl
+++ b/src/algorithms/linear_stretching.jl
@@ -58,7 +58,7 @@ imgo = adjust_histogram(img, LinearStretching(minval = 0, maxval = 1))
 1. W. Burger and M. J. Burge. *Digital Image Processing*. Texts in Computer Science, 2016. [doi:10.1007/978-1-4471-6684-9](https://doi.org/10.1007/978-1-4471-6684-9)
 
 """
-Base.@kwdef struct LinearStretching{T₁ <: Union{Real,AbstractGray},
+@with_kw struct LinearStretching{T₁ <: Union{Real,AbstractGray},
                                     T₂ <: Union{Real,AbstractGray}} <: AbstractHistogramAdjustmentAlgorithm
     minval::T₁ = 0.0
     maxval::T₂ = 1.0

--- a/src/algorithms/matching.jl
+++ b/src/algorithms/matching.jl
@@ -97,7 +97,7 @@ imshow(img_transformed)
 # References
 1. W. Burger and M. J. Burge. *Digital Image Processing*. Texts in Computer Science, 2016. [doi:10.1007/978-1-4471-6684-9](https://doi.org/10.1007/978-1-4471-6684-9)
 """
-Base.@kwdef struct Matching{T₁ <: AbstractArray,
+@with_kw struct Matching{T₁ <: AbstractArray,
                             T₂ <: Union{Integer, Nothing},
                             T₃ <: Union{AbstractRange, Nothing}} <: AbstractHistogramAdjustmentAlgorithm
     targetimg::T₁
@@ -108,7 +108,8 @@ end
 function (f::Matching)(out::GenericGrayImage, img::GenericGrayImage)
     #TODO Throw error/warning if user specifies both edges and nbins simultaneously.
     out .= img
-    edges, pdf, target_pdf = isnothing(f.edges) ? construct_pdfs(out, f.targetimg, f.nbins) : construct_pdfs(out, f.targetimg, f.edges)
+    # @compat statement required to support `isnothing` for Julia verion 1.0
+    @compat edges, pdf, target_pdf = isnothing(f.edges) ? construct_pdfs(out, f.targetimg, f.nbins) : construct_pdfs(out, f.targetimg, f.edges)
     match_pdf!(out, edges, pdf, target_pdf)
     return out
 end

--- a/src/algorithms/midway_equalization.jl
+++ b/src/algorithms/midway_equalization.jl
@@ -96,7 +96,7 @@ img2o = last(img_sequence)
 # References
 1. T. Guillemot and J. Delon, “*Implementation of the Midway Image Equalization*,” Image Processing On Line, vol. 5, pp. 114–129, Jun. 2016. [doi:10.5201/ipol.2016.140](https://doi.org/10.5201/ipol.2016.140)
 """
-Base.@kwdef struct MidwayEqualization{T₁ <: Union{Integer, Nothing},
+@with_kw struct MidwayEqualization{T₁ <: Union{Integer, Nothing},
                 					  T₂ <: Union{AbstractRange, Nothing}} <: AbstractHistogramAdjustmentAlgorithm
     nbins::T₁ = 256
     edges::T₂ = nothing
@@ -111,7 +111,8 @@ function (f::MidwayEqualization)(out_sequence::Vector{<:GenericGrayImage}, in_se
     in2 = last(in_sequence)
     out1 .= in1
     out2 .= in2
-    edges, pdf1, pdf2 = isnothing(f.edges) ? construct_pdfs(out1, out2, f.nbins) : construct_pdfs(out1, out2, f.edges)
+    # @compat statement required to support `isnothing` for Julia verion 1.0
+    @compat edges, pdf1, pdf2 = isnothing(f.edges) ? construct_pdfs(out1, out2, f.nbins) : construct_pdfs(out1, out2, f.edges)
     midway_pdf = zero(pdf1)
     cdf1 = cumsum(pdf1)
     cdf2 = cumsum(pdf2)


### PR DESCRIPTION
Replaces Base.@kw_def with @with_kw from Parameters.jl for compatilibity with Julia version 1.0. Also bumps patch version number in preparation for a new release.