### PR TITLE
Reverts the change associated with 0.3.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageContrastAdjustment"
 uuid = "f332f351-ec65-5f6a-b3d1-319c6670881a"
 authors = ["Dr. Zygmunt L. Szpak <zygmunt.szpak@gmail.com>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"

--- a/src/algorithms/matching.jl
+++ b/src/algorithms/matching.jl
@@ -105,14 +105,6 @@ imshow(img_transformed)
     edges::T₃ = nothing
 end
 
-# Required for backwards compatibility with Images.jl. Will be removed once
-# code in deprecations.jl in the Images.jl package is removed.
-function Matching()
-     Base.depwarn("`Matching()` is deprecated, use Matching(targetimg = targetimg) instead.", :Matching)
-    return Matching(targetimg = zeros(3,3))
-end
-
-
 function (f::Matching)(out::GenericGrayImage, img::GenericGrayImage)
     #TODO Throw error/warning if user specifies both edges and nbins simultaneously.
     out .= img


### PR DESCRIPTION
The change made in 0.3.2 still triggers a warning message. See: https://github.com/JuliaImages/Images.jl/pull/865#discussion_r371055652