### PR TITLE
LinearStretching enhancements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageContrastAdjustment"
 uuid = "f332f351-ec65-5f6a-b3d1-319c6670881a"
 authors = ["Dr. Zygmunt L. Szpak <zygmunt.szpak@gmail.com>"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"

--- a/src/algorithms/common.jl
+++ b/src/algorithms/common.jl
@@ -57,7 +57,3 @@ function cdf2pdf!(pdf::AbstractArray, cdf::AbstractArray)
         pdf[i] = cdf[i] - cdf[i-1]
     end
 end
-
-function linear_stretch(x, A, B, a, b)
-    return (x-A) * ((b-a)/(B-A)) + a
-end

--- a/src/algorithms/linear_stretching.jl
+++ b/src/algorithms/linear_stretching.jl
@@ -128,8 +128,8 @@ function (f::LinearStretching)(out::GenericGrayImage, img::GenericGrayImage)
     # the kernel operation `r * x - o` is equivalent to `(x-A) * ((b-a)/(B-A)) + a`
     # precalculate these and make inner loop contains only multiplication and addition
     # to get better performance
-    r = (dest_maxval - dest_minval) / (src_maxval - src_minval)
-    o = (src_minval*dest_maxval - src_maxval*dest_minval) / (src_maxval - src_minval)
+    r = convert(floattype(T), (dest_maxval - dest_minval) / (src_maxval - src_minval))
+    o = convert(floattype(T), (src_minval*dest_maxval - src_maxval*dest_minval) / (src_maxval - src_minval))
 
     if 1 ≈ r && 0 ≈ o
         # when image intensity is already adjusted, there's no need to do it again

--- a/src/algorithms/linear_stretching.jl
+++ b/src/algorithms/linear_stretching.jl
@@ -144,10 +144,9 @@ function (f::LinearStretching)(out::GenericGrayImage, img::GenericGrayImage)
     out_maxval = r * img_max - o
     do_clamp = (out_minval < dest_minval) || (out_maxval > dest_maxval)
 
-    # early convert type to hit faster clamp version
-    #  -- this might not be the root reason but it gives performance difference locally
-    dest_minval = convert(typeof(out_minval), dest_minval)
-    dest_maxval = convert(typeof(out_maxval), dest_maxval)
+    # strip the colorant type to hit faster clamp version
+    dest_minval = convert(floattype(eltype(typeof(out_minval))), dest_minval)
+    dest_maxval = convert(floattype(eltype(typeof(out_maxval))), dest_maxval)
 
     # tweak the performance of FixedPoint by fusing operations into one broadcast
     # for Float32 the fallback implementation is faster

--- a/src/algorithms/linear_stretching.jl
+++ b/src/algorithms/linear_stretching.jl
@@ -45,14 +45,14 @@ type as the input.
 
 ## Choices for `dst_minval` and `dst_maxval`
 
-If `dst_minval` and `dst_maxval` are specified then intensities are mapped to the range
-[`dst_minval`, `dst_maxval`]. The default values are 0 and 1.
+If destination value range `dst_minval` and `dst_maxval` are specified then intensities are
+mapped to the range [`dst_minval`, `dst_maxval`]. The default values are 0 and 1.
 
 ## Choices for `src_minval` and `src_maxval`
 
-`src_minval` and `src_maxval` specifies the intensity range of input image. By default,
-the values are `extrema(img)` (finite). If custom values are provided, the output
-intensity value will be clamped to range `(dst_minval, dst_maxval)` if it exceeds that.
+The source value range `src_minval` and `src_maxval` specifies the intensity range of input
+image. By default, the values are `extrema(img)` (finite). If custom values are provided,
+the output intensity value will be clamped to range `(dst_minval, dst_maxval)` if it exceeds that.
 
 # Example
 
@@ -60,8 +60,22 @@ intensity value will be clamped to range `(dst_minval, dst_maxval)` if it exceed
 using ImageContrastAdjustment, TestImages
 
 img = testimage("mandril_gray")
-imgo = adjust_histogram(img, LinearStretching(nothing=>(0, 1)))
+# Stretches the contrast in `img` so that it spans the unit interval.
+imgo = adjust_histogram(img, LinearStretching(dst_minval = 0, dst_maxval = 1))
+```
 
+Constructing a `LinearStretching` object using `Pair` is also supported
+
+```julia
+# these two constructors are equivalent
+LinearStretching(src_minval=0.1, src_maxval=0.9, dst_minval=0.05, dst_maxval=0.95)
+LinearStretching((0.1, 0.9)=>(0.05, 0.95))
+
+# replace the part with `nothing` to use default values, e.g.,
+# specify only destination value range
+LinearStretching(nothing=>(0.05, 0.95))
+# specify only source value range and use default destination value range, i.e., (0, 1)
+LinearStretching((0.1, 0.9)=>nothing)
 ```
 
 # References
@@ -113,8 +127,8 @@ end
 function LinearStretching(rangemap::Pair{Nothing, Tuple{T3, T4}}) where {T3, T4}
     LinearStretching(nothing, nothing, rangemap.second...)
 end
-function LinearStretching(src_range::Tuple{T1, T2}) where {T1, T2}
-    LinearStretching(src_minval=src_range[1], src_maxval=src_range[2])
+function LinearStretching(rangemap::Pair{Tuple{T1, T2}, Nothing}) where {T1, T2}
+    LinearStretching(src_minval=rangemap.first[1], src_maxval=rangemap.first[2])
 end
 
 function (f::LinearStretching)(out::GenericGrayImage, img::GenericGrayImage)

--- a/src/algorithms/linear_stretching.jl
+++ b/src/algorithms/linear_stretching.jl
@@ -64,14 +64,23 @@ imgo = adjust_histogram(img, LinearStretching(minval = 0, maxval = 1))
 1. W. Burger and M. J. Burge. *Digital Image Processing*. Texts in Computer Science, 2016. [doi:10.1007/978-1-4471-6684-9](https://doi.org/10.1007/978-1-4471-6684-9)
 
 """
-@with_kw struct LinearStretching{T₁ <: Union{Real,AbstractGray},
-                                 T₂ <: Union{Real,AbstractGray},
-                                 T₃ <: Union{Nothing, Real,AbstractGray},
-                                 T₄ <: Union{Nothing, Real,AbstractGray}} <: AbstractHistogramAdjustmentAlgorithm
-    minval::T₁     = 0.0
-    maxval::T₂     = 1.0
-    src_minval::T₃ = nothing
-    src_maxval::T₄ = nothing
+@with_kw struct LinearStretching{T} <: AbstractHistogramAdjustmentAlgorithm
+    minval::T     = 0.0f0
+    maxval::T     = 1.0f0
+    src_minval::T = nothing
+    src_maxval::T = nothing
+    function LinearStretching(minval::T1, maxval::T2, src_minval::T3, src_maxval::T4) where {
+                                                          T1 <: Union{Nothing,Real,AbstractGray},
+                                                          T2 <: Union{Nothing,Real,AbstractGray},
+                                                          T3 <: Union{Nothing,Real,AbstractGray},
+                                                          T4 <: Union{Nothing,Real,AbstractGray}}
+        minval <= maxval || throw(ArgumentError("minval $minval should be less than maxval $maxval"))
+        if !(isnothing(src_minval) || isnothing(src_maxval))
+            src_minval <= src_maxval || throw(ArgumentError("src_minval $src_minval should be less than src_maxval $src_maxval"))
+        end
+        T = promote_type(T1, T2, T3, T4)
+        new{T}(convert(T, minval), convert(T, maxval), convert(T, src_minval), convert(T, src_maxval))
+    end
 end
 
 function (f::LinearStretching)(out::GenericGrayImage, img::GenericGrayImage)

--- a/src/algorithms/linear_stretching.jl
+++ b/src/algorithms/linear_stretching.jl
@@ -5,7 +5,7 @@
     LinearStretching(; [src_minval], [src_maxval], dst_minval = 0, dst_maxval = 1)
 
     LinearStretching((src_minval, src_maxval) => (dst_minval, dst_maxval))
-    LinearStretching((src_minval, src_maxval))
+    LinearStretching((src_minval, src_maxval) => nothing)
     LinearStretching(nothing => (dst_minval, dst_maxval))
 
     adjust_histogram([T,] img, f::LinearStretching)
@@ -64,18 +64,18 @@ img = testimage("mandril_gray")
 imgo = adjust_histogram(img, LinearStretching(dst_minval = 0, dst_maxval = 1))
 ```
 
-Constructing a `LinearStretching` object using `Pair` is also supported
+For convenience, Constructing a `LinearStretching` object using `Pair` is also supported
 
 ```julia
 # these two constructors are equivalent
 LinearStretching(src_minval=0.1, src_maxval=0.9, dst_minval=0.05, dst_maxval=0.95)
-LinearStretching((0.1, 0.9)=>(0.05, 0.95))
+LinearStretching((0.1, 0.9) => (0.05, 0.95))
 
 # replace the part with `nothing` to use default values, e.g.,
 # specify only destination value range
-LinearStretching(nothing=>(0.05, 0.95))
+LinearStretching(nothing => (0.05, 0.95))
 # specify only source value range and use default destination value range, i.e., (0, 1)
-LinearStretching((0.1, 0.9)=>nothing)
+LinearStretching((0.1, 0.9) => nothing)
 ```
 
 # References

--- a/test/linear_stretching.jl
+++ b/test/linear_stretching.jl
@@ -1,7 +1,7 @@
 @testset "Linear Stretching" begin
 
     @test LinearStretching() === LinearStretching(nothing, nothing, 0.0f0, 1.0f0)
-    @test LinearStretching(src_minval=0.1f0, src_maxval=0.9f0, dest_minval=0.0f0, dest_maxval=1.0f0) ===
+    @test LinearStretching(src_minval=0.1f0, src_maxval=0.9f0, dst_minval=0.0f0, dst_maxval=1.0f0) ===
           LinearStretching(0.1f0, 0.9f0, 0.0f0, 1.0f0)
     @test LinearStretching((0.1f0, 0.9f0)=>(0.2f0, 0.8f0)) === LinearStretching(0.1f0, 0.9f0, 0.2f0, 0.8f0)
     @test LinearStretching(nothing=>(0.2f0, 0.8f0)) === LinearStretching((nothing, nothing)=>(0.2f0, 0.8f0))
@@ -90,8 +90,8 @@
 
     @testset "deprecations" begin
         @info "four depwarns are expected"
-        @test LinearStretching(minval = 0.1) === LinearStretching(dest_minval = 0.1)
-        @test LinearStretching(maxval = 0.9) === LinearStretching(dest_maxval = 0.9)
-        @test LinearStretching(minval = 0.1, maxval = 0.9) === LinearStretching(dest_minval = 0.1, dest_maxval = 0.9)
+        @test LinearStretching(minval = 0.1) === LinearStretching(dst_minval = 0.1)
+        @test LinearStretching(maxval = 0.9) === LinearStretching(dst_maxval = 0.9)
+        @test LinearStretching(minval = 0.1, maxval = 0.9) === LinearStretching(dst_minval = 0.1, dst_maxval = 0.9)
     end
 end

--- a/test/linear_stretching.jl
+++ b/test/linear_stretching.jl
@@ -46,6 +46,13 @@
         @test eltype(ret) == eltype(img)
         @test isapprox(0.2, minimum(ret))
         @test isapprox(0.8, maximum(ret))
+
+        # Verify that results are correctly clamped to [0.2, 0.9] if it exceeds the range
+        alg = LinearStretching(src_minval=0.1, src_maxval=0.8, minval=0.2, maxval=0.9)
+        ret = adjust_histogram(img, alg)
+        @test eltype(ret) == eltype(img)
+        @test isapprox(T(0.2), minimum(ret))
+        @test isapprox(T(0.9), maximum(ret), atol=1e-2) #
     end
 
     for T in (RGB{N0f8}, RGB{N0f16}, RGB{Float32}, RGB{Float64})

--- a/test/linear_stretching.jl
+++ b/test/linear_stretching.jl
@@ -1,5 +1,14 @@
 @testset "Linear Stretching" begin
 
+    @test LinearStretching() === LinearStretching(nothing, nothing, 0.0f0, 1.0f0)
+    @test LinearStretching(src_minval=0.1f0, src_maxval=0.9f0, minval=0.0f0, maxval=1.0f0) ===
+          LinearStretching(0.1f0, 0.9f0, 0.0f0, 1.0f0)
+    @test LinearStretching((0.1f0, 0.9f0)=>(0.2f0, 0.8f0)) === LinearStretching(0.1f0, 0.9f0, 0.2f0, 0.8f0)
+    @test LinearStretching(nothing=>(0.2f0, 0.8f0)) === LinearStretching((nothing, nothing)=>(0.2f0, 0.8f0))
+    @test LinearStretching((0.1f0, 0.9f0)) === LinearStretching(0.1f0, 0.9f0, 0.0f0, 1.0f0)
+    @test_throws MethodError LinearStretching(0.1f0, 0.9f0)
+    @test_throws MethodError LinearStretching((0.1f0, 0.9f0), (0.0f0, 1.0f0))
+
     for T in (Gray{N0f8}, Gray{N0f16}, Gray{Float32}, Gray{Float64})
         #=
         Stretching an image consisting of a linear ramp should not change the image
@@ -48,11 +57,10 @@
         @test isapprox(0.8, maximum(ret))
 
         # Verify that results are correctly clamped to [0.2, 0.9] if it exceeds the range
-        alg = LinearStretching(src_minval=0.1, src_maxval=0.8, minval=0.2, maxval=0.9)
-        ret = adjust_histogram(img, alg)
+        ret = adjust_histogram(img, LinearStretching((0.1, 0.8)=>(0.2, 0.9)))
         @test eltype(ret) == eltype(img)
         @test isapprox(T(0.2), minimum(ret))
-        @test isapprox(T(0.9), maximum(ret), atol=1e-2) #
+        @test isapprox(T(0.9), maximum(ret), atol=1e-2)
     end
 
     for T in (RGB{N0f8}, RGB{N0f16}, RGB{Float32}, RGB{Float64})

--- a/test/linear_stretching.jl
+++ b/test/linear_stretching.jl
@@ -5,7 +5,7 @@
           LinearStretching(0.1f0, 0.9f0, 0.0f0, 1.0f0)
     @test LinearStretching((0.1f0, 0.9f0)=>(0.2f0, 0.8f0)) === LinearStretching(0.1f0, 0.9f0, 0.2f0, 0.8f0)
     @test LinearStretching(nothing=>(0.2f0, 0.8f0)) === LinearStretching((nothing, nothing)=>(0.2f0, 0.8f0))
-    @test LinearStretching((0.1f0, 0.9f0)) === LinearStretching(0.1f0, 0.9f0, 0.0f0, 1.0f0)
+    @test LinearStretching((0.1f0, 0.9f0)=>nothing) === LinearStretching(0.1f0, 0.9f0, 0.0f0, 1.0f0)
     @test_throws MethodError LinearStretching(0.1f0, 0.9f0)
     @test_throws MethodError LinearStretching((0.1f0, 0.9f0), (0.0f0, 1.0f0))
 


### PR DESCRIPTION
It's just a prototype for #27 , does this usage look good to you? 

```julia
img = float.(testimage("mandril_gray"))
imgo = adjust_histogram(img, LinearStretching(src_minval=0.1, src_maxval=0.9))
```

Note that this implementation doesn't always work for `N0f8` types, there're two ways to work this around: clamp01 or promote storage type. I'm not sure which is better.

cc: @zygmuntszpak @bjarthur