### PR TITLE
Bring docs stage back in travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ after_success:
 jobs:
   include:
     - stage: "Documentation"
-      julia: 1.1.0
+      julia: 1.0
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ julia:
   - 1.0
   - 1
   - nightly
-# matrix:
-#   allow_failures:
-#     - julia: nightly
-#   fast_finish: true
+jobs:
+  allow_failures:
+    - julia: nightly
+  fast_finish: true
 notifications:
   email: false
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,7 @@ julia:
   - 1.0
   - 1
   - nightly
-jobs:
-  allow_failures:
-    - julia: nightly
-  fast_finish: true
+
 notifications:
   email: false
 after_success:
@@ -27,3 +24,8 @@ jobs:
                                                Pkg.instantiate()'
         - julia --project=docs/ docs/make.jl
       after_success: skip
+  
+  allow_failures:
+  - julia: nightly
+
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ julia:
   - 1.0
   - 1
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
-  fast_finish: true
+# matrix:
+#   allow_failures:
+#     - julia: nightly
+#   fast_finish: true
 notifications:
   email: false
 after_success:
@@ -20,7 +20,7 @@ after_success:
 jobs:
   include:
     - stage: "Documentation"
-      julia: 1.0
+      julia: 1.1.0
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));


### PR DESCRIPTION
Travis seems to not understand the configuration and missed the docs stage. (e.g., https://travis-ci.org/github/JuliaImages/ImageContrastAdjustment.jl/builds/667514858)

I'm not sure if this fixes the problem, so there might be many commits here.

Looks like the docs in ImageBinarization aren't updated as well...