### PR TITLE
Obtain MappedArrays from ImageCore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,14 +7,12 @@ version = "0.3.5"
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
-MappedArrays = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 
 [compat]
 ColorVectorSpace = "0.6, 0.7, 0.8"
 ImageCore = "0.8.5"
 ImageTransformations = "0.8.1"
-MappedArrays = "0.2.2"
 Parameters = "0.12"
 julia = "1"
 

--- a/src/ImageContrastAdjustment.jl
+++ b/src/ImageContrastAdjustment.jl
@@ -3,7 +3,8 @@ module ImageContrastAdjustment
 using ColorVectorSpace
 using ImageCore
 using ImageTransformations: imresize
-using MappedArrays
+# Where possible we avoid a direct dependency to reduce the number of [compat] bounds
+using ImageCore.MappedArrays
 using Parameters: @with_kw # Same as Base.@kwdef but works on Julia 1.0
 
 # TODO: port HistogramAdjustmentAPI to ImagesAPI


### PR DESCRIPTION
That way we don't have so many [compat] bounds to bump.

xref https://github.com/JuliaImages/ImageQualityIndexes.jl/pull/26 for the backstory.