### PR TITLE
Update ImageTransformation to v0.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageContrastAdjustment"
 uuid = "f332f351-ec65-5f6a-b3d1-319c6670881a"
 authors = ["Dr. Zygmunt L. Szpak <zygmunt.szpak@gmail.com>"]
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
@@ -10,7 +10,7 @@ Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 
 [compat]
 ImageCore = "0.9"
-ImageTransformations = "0.8.1"
+ImageTransformations = "0.8.1, 0.9"
 Parameters = "0.12"
 julia = "1"
 


### PR DESCRIPTION
This PR updates ImageTransformations to v0.9 and releases it as a patch version.
