### PR TITLE
More optimizations

### DIFF
--- a/src/algorithms/common.jl
+++ b/src/algorithms/common.jl
@@ -19,6 +19,7 @@ end
 
 function build_lookup(cdf, minval::T, maxval::T) where T
     first_cdf = first(cdf)
+    # Scale the new intensity value to so that it lies in the range [minval, maxval].
     scale = (maxval - minval) / (cdf[end] - first_cdf)
     if T <: Integer
         return T[ceil(minval + (x - first_cdf) * scale) for x in cdf]

--- a/src/algorithms/equalization.jl
+++ b/src/algorithms/equalization.jl
@@ -104,13 +104,14 @@ imshow(imgeq)
 end
 
 function (f::Equalization)(out::GenericGrayImage, img::GenericGrayImage)
-    edges, histogram = build_histogram(img, f.nbins, minval = f.minval, maxval = f.maxval)
+    minval, maxval = convert(eltype(out), f.minval), convert(eltype(out), f.maxval)
+    edges, histogram = build_histogram(img, f.nbins, minval = minval, maxval = maxval)
     lb = first(axes(histogram,1))
     ub = last(axes(histogram,1))
     N = length(img)
     cdf = cumsum(histogram[lb:ub]/N)
-    out .= img
-    transform_density!(out, edges, cdf, f.minval, f.maxval)
+    newvals = build_lookup(cdf, minval, maxval)
+    transform_density!(out, img, edges, newvals)
 end
 
 function (f::Equalization)(out::AbstractArray{<:Color3}, img::AbstractArray{<:Color3})

--- a/src/build_histogram.jl
+++ b/src/build_histogram.jl
@@ -188,17 +188,16 @@ function build_histogram(img::GenericGrayImage, edges::AbstractRange)
     Base.has_offset_axes(edges) && throw(ArgumentError("edges must be indexed starting with 1"))
     lb = first(axes(edges,1))-1
     ub = last(axes(edges,1))
-    first_edge = first(edges)
+    first_edge, last_edge = first(edges), last(edges)
     inv_step_size = 1/step(edges)
     counts = fill(0, lb:ub)
-    for val in img
+    @inbounds for val in img
          if isnan(val)
              continue
          else
-            if val >= edges[end]
-                counts[end] += 1
-                continue
-            elseif val < first(edges)
+            if val >= last_edge
+                counts[ub] += 1
+            elseif val < first_edge
                 counts[lb] += 1
             else
                 index = floor(Int, gray((val-first_edge)*inv_step_size)) + 1


### PR DESCRIPTION
#17 made steps to improve performance, but there was still more that could be done:

- hoist more invariant array-access out of loops
- precompute the `inputval => outputval` lookup table. This saves unnecessary arithmetic and `convert` operations
- skip a `out .= img`, which just added an unnecessary trip through both arrays
- use `@inbounds` in a few more places

The aggregate impact: on master,
```julia
julia> using ImageContrastAdjustment, BenchmarkTools

julia> img = rand(Float32, 2048, 2048);

julia> @btime adjust_histogram($img, Equalization(nbins = 256));
  44.144 ms (6 allocations: 16.01 MiB)
```

but on this branch

```julia
julia> @btime adjust_histogram($img, Equalization(nbins = 256));
  18.238 ms (7 allocations: 16.01 MiB)
```