### PR TITLE
Adds PiecewiseLinearStretching 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,21 @@
 name = "ImageContrastAdjustment"
 uuid = "f332f351-ec65-5f6a-b3d1-319c6670881a"
-authors = ["Dr. Zygmunt L. Szpak <zygmunt.szpak@gmail.com>"]
-version = "0.3.10"
+authors = ["Dr. Zygmunt L. Szpak <zygmunt.szpak@gmail.com> and contributors"]
+version = "0.4.0"
 
 [deps]
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
+IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 ImageCore = "0.9.3"
 ImageTransformations = "0.8.1, 0.9"
+IntervalSets = "0.5.3"
 Parameters = "0.12"
+Reexport = "1.2.2"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 ImageCore = "0.9.3"
@@ -16,14 +17,16 @@ ImageTransformations = "0.8.1, 0.9"
 IntervalSets = "0.5.3"
 Parameters = "0.12"
 Reexport = "1.2.2"
+StatsBase = "0.33"
 julia = "1"
 
 [extras]
 ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
+ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["Test", "ImageFiltering", "TestImages", "ImageMagick", "LinearAlgebra"]
+test = ["Test", "ImageFiltering", "TestImages", "ImageMagick", "ImageIO", "LinearAlgebra"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+ImageContrastAdjustment = "f332f351-ec65-5f6a-b3d1-319c6670881a"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 ImageShow = "4e3cecfd-b093-5904-9786-8bbb286a6a31"

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -13,6 +13,12 @@ adjust_histogram!
 build_histogram
 ```
 
+## Adjunt Types
+```@docs
+Percentiles
+MinMax
+```
+
 ## Algorithms
 
 ```@docs

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -48,3 +48,8 @@ Matching
 ```@docs
 MidwayEqualization
 ```
+
+### PiecewiseLinearStretching
+```@docs
+PiecewiseLinearStretching
+```

--- a/src/ImageContrastAdjustment.jl
+++ b/src/ImageContrastAdjustment.jl
@@ -4,7 +4,10 @@ using ImageCore
 using ImageTransformations: imresize
 # Where possible we avoid a direct dependency to reduce the number of [compat] bounds
 using ImageCore.MappedArrays
+using IntervalSets
 using Parameters: @with_kw # Same as Base.@kwdef but works on Julia 1.0
+using Reexport
+@reexport using IntervalSets
 
 # TODO: port HistogramAdjustmentAPI to ImagesAPI
 include("HistogramAdjustmentAPI/HistogramAdjustmentAPI.jl")

--- a/src/ImageContrastAdjustment.jl
+++ b/src/ImageContrastAdjustment.jl
@@ -7,6 +7,7 @@ using ImageCore.MappedArrays
 using IntervalSets
 using Parameters: @with_kw # Same as Base.@kwdef but works on Julia 1.0
 using Reexport
+using StatsBase: percentile
 @reexport using IntervalSets
 
 # TODO: port HistogramAdjustmentAPI to ImagesAPI
@@ -16,6 +17,23 @@ import .HistogramAdjustmentAPI: AbstractHistogramAdjustmentAlgorithm,
 
 # TODO Relax this to all image color types
 const GenericGrayImage = AbstractArray{<:Union{Number, AbstractGray}}
+
+# Temporary definition which will be moved to ImageCore.
+"""
+    Percentiles(p₁, p₂, p₃, ..., pₙ)
+Specifies a length-n list of [percentiles](https://en.wikipedia.org/wiki/Percentile).
+"""
+struct Percentiles{T} <: Real
+    p::T
+end
+Percentiles(args...) = Percentiles(tuple(args...))
+"""
+    MinMax()
+A type that can be used to signal to [`PiecewiseLinearStretching`](@ref) that it should
+use the mininum and maximum value in an image as it source or destination interval. 
+"""
+struct MinMax end
+
 
 include("core.jl")
 include("build_histogram.jl")
@@ -40,6 +58,8 @@ export
     LinearStretching,
     ContrastStretching,
     PiecewiseLinearStretching,
+    Percentiles,
+    MinMax,
     build_histogram,
     adjust_histogram,
     adjust_histogram!

--- a/src/ImageContrastAdjustment.jl
+++ b/src/ImageContrastAdjustment.jl
@@ -24,6 +24,7 @@ include("algorithms/contrast_stretching.jl")
 include("algorithms/gamma_correction.jl")
 include("algorithms/matching.jl")
 include("algorithms/midway_equalization.jl")
+include("algorithms/piecewise_linear_stretching.jl")
 include("compat.jl")
 
 export
@@ -35,6 +36,7 @@ export
     GammaCorrection,
     LinearStretching,
     ContrastStretching,
+    PiecewiseLinearStretching,
     build_histogram,
     adjust_histogram,
     adjust_histogram!

--- a/src/algorithms/piecewise_linear_stretching.jl
+++ b/src/algorithms/piecewise_linear_stretching.jl
@@ -1,0 +1,179 @@
+"""
+```
+    PiecewiseLinearStretching <: AbstractHistogramAdjustmentAlgorithm
+    PiecewiseLinearStretching(;  src_intervals = (0.0 => 0.1, 0.1 => 0.9, 0.9 => 1.0), 
+                                 dst_intervals = (0.0 => 0.2, 0.2 => 1.0, 1.0 => 1.0))
+
+    adjust_histogram([T,] img, f::PiecewiseLinearStretching)
+    adjust_histogram!([out,] img, f::PiecewiseLinearStretching)
+```
+
+Returns an image for which the intensity range was partitioned into subintervals (specified
+by `src_intervals`) and mapped linearly to a new set of subintervals
+(specified by `dst_intervals`). 
+
+# Details
+
+Piecewise linear stretching is a contrast enhancing transformation that is used to modify
+the dynamic range of an image. The concept involves partitioning the intensity
+range of an image, ``I = [A,B]`` into a sequence of ``m`` disjoint intervals
+
+```math
+I_1 = [A_1,A_2], I_2 = (A_2, A_3], \\ldots, I_{m} = (A_m,A_{m+1}]
+```
+which encompass the entire range of intensity values such that ``\\sum_j |I_j | = | I |``. 
+One subsequently constructs a concomitant new set of disjoint intervals
+```math
+I_{1}^{′} = [a_1,a_2], I_{2}^{′} = (a_2, a_3], \\ldots, I_{m}^{′} = (a_m,a_{m+1}]
+```
+such that ``\\sum_j |I_{j}^{′} | = | I^{′} |``, where ``I^{′} = [a,b]``. Finally, one introduces a
+sequence of mappings ``f_j : I_j \\to I_{j}^{′}`` ``(j = 1, \\ldots, m)`` given by
+```math
+f_j(x) = (x-A_{j}) \\frac{a_{j+1}-a_j}{A_{j+1}-A_{j}} + a_j.
+```
+which linearly map intensities from the interval ``I_j`` to the interval ``I_{j}^{′}`` .
+
+# Options
+
+Various options for the parameters of the `adjust_histogram` and
+`PiecewiseLinearStretching` type are described in more detail below.
+
+## Choices for `img`
+
+The function can handle a variety of input types. The returned image depends on the input
+type.
+
+For colored images, the input is converted to the [YIQ](https://en.wikipedia.org/wiki/YIQ)
+type and the intensities of the Y channel are stretched to the specified range. The modified
+Y channel is then combined with the I and Q channels and the resulting image converted to
+the same type as the input.
+
+## Choices for `src_intervals` 
+
+The `src_intervals` must be specified as an `ntuple` of pairs. For example,
+`src_intervals = (0.0 => 0.2, 0.2 => 0.8, 0.8 => 1.0)` partitions the unit
+interval into three subintervals, [0.0, 0.2], (0.2, 0.8] and (0.8, 1.0]. 
+
+To specify a single interval you must include a trailing comma, e.g.
+`src_intervals = (0.0 => 1.0,)`. 
+
+The start and end of a subinterval in `src_intervals` cannot be equal. For example,
+`src_intervals = (0.0 => 0.5, 0.5 => 0.5, 0.5 => 1.0)` will result in an `ArgumentError`
+because of the pair `0.5 => 0.5`.
+
+## Choices for `dst_intervals` 
+
+The `dst_intervals` must be specified as an `ntuple` of pairs and there needs to be a
+corresponding pair for each pair in `src_intervals`.
+    
+Unlike `src_intervals`, the start and end of an interval in `src_intervals` can be equal.
+For example, the combination `src_intervals = (0.0 => 0.5, 0.5 => 1.0)` and `dst_intervals =
+(0.0 => 0.0 , 1.0 => 1.0)` will produce a binary image. 
+
+Care must be taken to ensure that the subintervals specified in `dst_intervals` are
+representable within the type of image on which the piecewise linear stretching will be
+applied. For example, if you specify a negative output interval like `dst_intervals = (1.0
+=> -1.0),` and try to apply the transformation on an image with type `Gray{N0f8}`, you will
+receive a DomainError. 
+
+## Saturating pixels
+
+If the specified `src_intervals` don't span the entire range of intensities in an image,
+then intensities that fall outside `src_intervals` are automatically set to the boundary
+values of the `dst_intervals`. For example, given the combination `src_intervals = (0.1 =>
+0.9, )` and `dst_intervals = (0.0 => 1.0)`, intensities below `0.1` are set to zero, and
+intensities above `0.9` are set to one. 
+
+# Example
+
+```julia
+using ImageContrastAdjustment, TestImages
+
+img = testimage("mandril_gray")
+# Stretches the contrast in `img` so that it spans the unit interval.
+f = PiecewiseLinearStretching(src_intervals = (0.0 => 0.2, 0.2 => 0.8, 0.8 => 1.0),
+                              dst_intervals = (0.0 => 0.4, 0.4 => 0.9, 0.9 => 1.0))
+imgo = adjust_histogram(img, f)
+```
+
+# References
+1. W. Burger and M. J. Burge. *Digital Image Processing*. Texts in Computer Science, 2016. [doi:10.1007/978-1-4471-6684-9](https://doi.org/10.1007/978-1-4471-6684-9)
+"""
+@with_kw struct PiecewiseLinearStretching{T} <: AbstractHistogramAdjustmentAlgorithm where T <: NTuple{N, Pair{<: Union{Real, AbstractGray}, <: Union{Real, AbstractGray}}} where {N}
+    src_intervals::T = (0.0 => 0.1, 0.1 => 0.9, 0.9 => 1.0)
+    dst_intervals::T = (0.0 => 0.2, 0.2 => 1.0, 1.0 => 1.0)
+    function PiecewiseLinearStretching(src_intervals::T₁, dst_intervals::T₂) where {T₁ <: NTuple{N₁, Pair{<: Union{Real, AbstractGray}, <: Union{Real, AbstractGray}}} where {N₁}, T₂ <: NTuple{N₂, Pair{<: Union{Real, AbstractGray}, <: Union{Real, AbstractGray}}} where {N₂}}  
+        length(src_intervals) == length(dst_intervals) ||  throw(ArgumentError("The dst_intervals must define an interval pair for each consecutive src_interval pair, i.e. length(src_intervals) == length(dst_intervals)."))
+        for src_pair in src_intervals
+            if first(src_pair) == last(src_pair) 
+                throw(ArgumentError("The start and end of an interval in src_intervals cannot be equal."))
+            end
+        end
+        T = promote_type(T₁, T₂)
+        new{T}(src_intervals, dst_intervals)
+    end    
+end
+
+function (f::PiecewiseLinearStretching)(out::GenericGrayImage, img::GenericGrayImage) 
+    # Verify that the specified dst_intervals fall inside the permissible range
+    # of the output type. 
+    T = eltype(out)
+    for (a,b) in f.dst_intervals
+        p = typemin(T)
+        r = typemax(T)
+        if  !(p <= a <= r) || !(p <= b <= r)
+            throw(DomainError("The specified interval [$a, $b] falls outside the permissible range [$p, $r] associated with $T"))
+        end
+    end
+    # A linear mapping of a value x in the interval [A, B] to the interval [a,b] is given by
+    # the formula f(x) = (x-A) * ((b-a)/(B-A)) + a. The operation r * x - o is equivalent to
+    # (x-A) * ((b-a)/(B-A)) + a. Precalculate the r and o so that later on an inner loop
+    # contains only multiplication and addition to get better performance.
+    N = length(f.src_intervals)
+    rs = zeros(Float64, N)
+    os = zeros(Float64, N)
+    for (src, dst) in zip(pairs(f.src_intervals), pairs(f.dst_intervals)) 
+        n, (A,B) = src
+        _, (a,b) = dst   
+        rs[n] = (b - a) / (B - A)
+        os[n] = (A*b - B*a) / (B - A)
+    end
+
+    # Determine which interval the source pixel fall into, and apply the accompanying linear
+    # transformation taking into account NaN values. 
+    @inbounds for p in eachindex(img)
+        val = img[p]
+        if isnan(val)
+            out[p] = val
+        else
+            is_inside_src_intervals = false
+            for (n, (A,B)) in pairs(f.src_intervals)                                 
+                if (A <= val < B) || (A <= val <= B && n == N)       
+                    newval = rs[n] * val - os[n]                                                                          
+                    out[p] = T <: Integer ? round(Int, newval) : newval  
+                    is_inside_src_intervals = true  
+                    break                                                                                   
+                end                                                                                                    
+            end 
+            if !is_inside_src_intervals
+                # Saturate pixels that fall outside the specified src_intervals by setting
+                # them equal to the start/end of the edge dst_intervals. 
+                a = first(first(f.dst_intervals))
+                b = last(last(f.dst_intervals))
+                A = first(first(f.src_intervals))
+                newval = val < A ? a : b
+                out[p] = T <: Integer ? round(Int, newval) : newval  
+            end 
+        end
+    end
+   return out                                                                                                                                                                                                             
+end 
+
+function (f::PiecewiseLinearStretching)(out::AbstractArray{<:Color3}, img::AbstractArray{<:Color3})
+    T = eltype(out)
+    yiq = convert.(YIQ, img)
+    yiq_view = channelview(yiq)
+    adjust_histogram!(view(yiq_view,1,:,:), f)
+    out .= convert.(T, yiq)
+end
+                                                                                                                                                                                                   

--- a/test/piecewise_linear_stretching.jl
+++ b/test/piecewise_linear_stretching.jl
@@ -1,0 +1,170 @@
+@testset "Piecewise Linear Stretching" begin
+
+    @testset "constructors" begin
+        @test_throws ArgumentError PiecewiseLinearStretching(
+                                src_intervals = ((0.0 => 0.2),(0.2 => 0.2), (0.8 => 1.0)), 
+                                dst_intervals = ((0.0 => 0.2),(-1.0 => 0.0),(1 => -2)))
+  
+        @test_throws ArgumentError PiecewiseLinearStretching(
+                                src_intervals = ((0.0 => 0.2),(0.2 => 0.8), (0.8 => 1.0)), 
+                                dst_intervals = ((0.0 => 0.2), (1 => -2)))      
+    end
+    @testset "miscellaneous" begin
+        # We should be able to invert the image. 
+        f = PiecewiseLinearStretching(src_intervals = (0.0 => 1.0,), dst_intervals = (1.0 => 0.0,))   
+        for T in (Gray{N0f8}, Gray{N0f16}, Gray{Float32}, Gray{Float64})
+            img = T.(testimage("mandril_gray"))
+            ret = adjust_histogram(img, f)
+            @test ret ≈ (1 .- img)
+        end  
+
+        # We should be able to binarize the image. 
+        f = PiecewiseLinearStretching(
+                                      src_intervals = ((0.0 => 0.5), (0.5 => 1.0)), 
+                                      dst_intervals = ((0.0 => 0.0),(1.0 => 1.0)))
+        for T in (Gray{N0f8}, Gray{N0f16}, Gray{Float32}, Gray{Float64})
+            img = T.(testimage("mandril_gray"))
+
+            ret = adjust_histogram(img, f)
+            vals = sort(unique(ret))
+            @test first(vals) == 0.0
+            @test last(vals) == 1.0
+        end  
+
+        # Setting the src_intervals equal to the dst_intervals should result in an identity
+        # mapping (no change to the image) provided that the src_intervals span the entire
+        # permissible contrast range, i.e. the unit interval. 
+        f = PiecewiseLinearStretching(
+                                src_intervals = ((0.0 => 0.3), (0.3 => 0.8), (0.8 => 1.0)), 
+                                dst_intervals = ((0.0 => 0.3), (0.3 => 0.8), (0.8 => 1.0)))
+        for T in (Gray{N0f8}, Gray{N0f16}, Gray{Float32}, Gray{Float64})
+            img = T.(testimage("mandril_gray"))
+            ret = adjust_histogram(img, f)
+            @test ret ≈  img
+        end   
+
+        # If the src_intervals equal the dst_intervals, but the src_intervals don't span the
+        # entire permissible contrast range, i.e. the unit interval, then the resulting
+        # image will not match the original image because pixels that fall outside the
+        # specified src_intervals are satuared to the edge value of src_intervals. 
+        f = PiecewiseLinearStretching(
+                                      src_intervals = ((0.3 => 0.8),), 
+                                      dst_intervals = ((0.3 => 0.8),))
+        for T in (Gray{N0f8}, Gray{N0f16}, Gray{Float32}, Gray{Float64})
+            img = T.(testimage("mandril_gray"))
+            ret = adjust_histogram(img, f)
+            @test !isapprox(ret, 1 .- img, atol=1e-1)
+        end  
+
+        for T in (Gray{N0f8}, Gray{N0f16}, Gray{Float32}, Gray{Float64})
+            #=
+            Stretching an image consisting of a linear ramp should not change the image
+            if the specified minimum and maximum values match the minimum and maximum of
+            the image.
+            =#
+            img = T.(collect(reshape(1/100:1/100:1, 10, 10)))
+            minval = minimum(img)
+            maxval = maximum(img)
+            f = PiecewiseLinearStretching(src_intervals = (minval => maxval,), dst_intervals = (minval => maxval,))   
+            ret =  adjust_histogram(img, f)
+            if T <: Gray{Float32} || T <: Gray{Float64}
+                @test all(map((i, r) -> isapprox(i, r), img, ret))
+            else
+                @test ret == img
+            end
+
+            # Verify that NaN is also handled correctly.
+            if T <: Gray{Float32} || T <: Gray{Float64}
+                img[10] = NaN
+                ret = adjust_histogram(img, f)
+                @test isapprox(first(img), first(ret))
+                @test isapprox(last(img), last(ret))
+                @test isnan(ret[10])
+            end
+
+            # Verify that the smallest and largest values match the specified minval and maxval.
+            img = T.(collect(reshape(1/100:1/100:1, 10, 10)))
+            minval = minimum(img)
+            maxval = maximum(img)
+            f = PiecewiseLinearStretching(src_intervals = (minval => maxval,), dst_intervals = (0.0 => 1.0,)) 
+            ret =  adjust_histogram(img, f)
+            @test isapprox(0, first(ret))
+            @test isapprox(1, last(ret))
+            @test isapprox(0, minimum(ret[.!isnan.(ret)]))
+            @test isapprox(1, maximum(ret[.!isnan.(ret)]))
+
+            # Verify that the return type matches the input type.
+            img = T.(testimage("mandril_gray"))
+            minval = minimum(img)
+            maxval = maximum(img)
+            f = PiecewiseLinearStretching(src_intervals = (minval => maxval,), dst_intervals = (0.0 => 1.0,)) 
+            ret = adjust_histogram(img, f)
+            @test eltype(ret) == eltype(img)
+            @test isapprox(0, minimum(ret))
+            @test isapprox(1, maximum(ret))
+
+            f = PiecewiseLinearStretching(src_intervals = (0.0 => 1.0,), dst_intervals = (0.2 => 0.8,)) 
+            ret = adjust_histogram(img, f)
+            @test eltype(ret) == eltype(img)
+            # We are mapping the interval [0, 1] to [0.2, 0.8] but since the 
+            # smallest intensity in the mandril image need not be zero, and the largest
+            # need to be one, smallest and largest observed values in the 
+            # image need not be 0.2 and 0.8, but should still be within those bounds. 
+            @test minimum(ret) >= 0.2 
+            @test maximum(ret) <= 0.8 
+
+            # Verify that results are correctly clamped to [0.2, 0.9] if it exceeds the range
+            f = PiecewiseLinearStretching(src_intervals = (0.3 => 0.8,),
+                                          dst_intervals = (0.2 => 0.9,))
+            ret = adjust_histogram(img, f)
+            @test eltype(ret) == eltype(img)
+            @test minimum(ret) == T(0.2)
+            @test maximum(ret) == T(0.9)  
+        end
+
+        img = Float32.(collect(reshape(1/100:1/100:1, 10, 10)))
+
+        f = PiecewiseLinearStretching(src_intervals = ((0.0 => 1.0),), dst_intervals = ((-1.0 => 0.0),))
+        ret = adjust_histogram(img, f)
+        @test eltype(ret) == eltype(img)
+        # @test minimum(ret) ≈ -1.0
+        # @test maximum(ret) ≈ 0.0
+        @test isapprox(minimum(ret), -1.0, atol=1e-1)
+        @test isapprox(maximum(ret), 0.0, atol=1e-1)
+        @test_throws DomainError adjust_histogram(Gray{N0f8}.(img), f)
+
+        img = Gray{Float32}.(collect(reshape(1/100:1/100:1, 10, 10)))
+        f = PiecewiseLinearStretching(src_intervals = ((0.0 => 0.2), (0.2 => 0.8), (0.8 => 1.0)), dst_intervals = ((0.0 => 0.2), (-1.0 => 0.0), (1 => -2)))
+        ret = adjust_histogram(img, f)
+        @test eltype(ret) == eltype(img)
+        @test minimum(ret) ≈ -2.0
+        @test maximum(ret) ≈ 1.0
+
+        for T in (RGB{N0f8}, RGB{N0f16}, RGB{Float32}, RGB{Float64})
+            #=
+            Create a color image that spans a narrow graylevel range.  Then
+            quantize the 256 bins down to 32 and determine how many bins have
+            non-zero counts.
+            =#
+            imgg = Gray{Float32}.([i/255.0 for i = 64:128, j = 1:10])
+            img = colorview(RGB,imgg,imgg,imgg)
+            img = T.(img)
+            _, counts_before = build_histogram(img,32, minval = 0, maxval = 1)
+            nonzero_before = sum(counts_before .!= 0)
+    
+            #=
+            Stretch the histogram. Then quantize the 256 bins down to 32 and
+            verify that all 32 bins have non-zero counts. This will confirm that
+            the dynamic range of the original image has been increased.
+            =#
+            f = PiecewiseLinearStretching(src_intervals = (0.3 => 0.5,), 
+                                          dst_intervals = (0.0 => 1.0,))
+            ret = adjust_histogram(img, f)
+            edges, counts_after = build_histogram(ret, 32, minval = 0, maxval = 1)
+            nonzero_after = sum(counts_after .!= 0)
+            @test nonzero_before < nonzero_after
+            @test nonzero_after == 32
+            @test eltype(img) == eltype(ret)
+        end    
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,4 +11,5 @@ using Test, ImageCore, ImageFiltering, TestImages, LinearAlgebra
     include("gamma_adjustment.jl")
     include("linear_stretching.jl")
     include("contrast_stretching.jl")
+    include("piecewise_linear_stretching.jl")
 end


### PR DESCRIPTION
Adds `PiecewiseLinearStretching` as a basis for addressing https://github.com/JuliaImages/ImageContrastAdjustment.jl/issues/33

Currently, I have implemented this under the old `adjust_histogram` umbrella. The intention is to refactor everything into `adjust_intensities` in subsequent pull requests. 

The next steps involve adding `Percentile` and perhaps `Quantile` types to `ImageCore` to facilitate the implementation of some convenience functions described in https://github.com/JuliaImages/ImageContrastAdjustment.jl/issues/33 and other places.