### PR TITLE
Precompute lookup for N0f8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageContrastAdjustment"
 uuid = "f332f351-ec65-5f6a-b3d1-319c6670881a"
 authors = ["Dr. Zygmunt L. Szpak <zygmunt.szpak@gmail.com>"]
-version = "0.3.9"
+version = "0.3.10"
 
 [deps]
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
@@ -9,7 +9,7 @@ ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 
 [compat]
-ImageCore = "0.9"
+ImageCore = "0.9.3"
 ImageTransformations = "0.8.1, 0.9"
 Parameters = "0.12"
 julia = "1"

--- a/src/algorithms/common.jl
+++ b/src/algorithms/common.jl
@@ -18,6 +18,9 @@ function transform_density!(out::GenericGrayImage, img::GenericGrayImage, edges:
 end
 
 function transform_density!(out::GenericGrayImage, img::GenericGrayImage{T}, edges::AbstractRange, newvals::AbstractVector) where T<:Union{N0f8,AbstractGray{N0f8}}
+    # When dealing with 8-bit images, we can improve computational performance by precomputing the lookup table
+    # for how the intensities transform (there are only 256 calculations of intensities rather than `length(img)`
+    # calculations of intensities).
     lookup = Vector{eltype(newvals)}(undef, 256)
     invoke(transform_density!, Tuple{GenericGrayImage,GenericGrayImage,AbstractRange,AbstractVector},
                                lookup, zero(T):eps(T):oneunit(T), edges, newvals)

--- a/src/algorithms/common.jl
+++ b/src/algorithms/common.jl
@@ -17,6 +17,18 @@ function transform_density!(out::GenericGrayImage, img::GenericGrayImage, edges:
     map!(transform, out, img)
 end
 
+function transform_density!(out::GenericGrayImage, img::GenericGrayImage{T}, edges::AbstractRange, newvals::AbstractVector) where T<:Union{N0f8,AbstractGray{N0f8}}
+    lookup = Vector{eltype(newvals)}(undef, 256)
+    invoke(transform_density!, Tuple{GenericGrayImage,GenericGrayImage,AbstractRange,AbstractVector},
+                               lookup, zero(T):eps(T):oneunit(T), edges, newvals)
+    map!(out, img) do val
+        lookup[uint8val(val)+1]
+    end
+end
+
+uint8val(x::N0f8) = reinterpret(x)
+uint8val(x::AbstractGray) = uint8val(gray(x))
+
 function build_lookup(cdf, minval::T, maxval::T) where T
     first_cdf = first(cdf)
     # Scale the new intensity value to so that it lies in the range [minval, maxval].


### PR DESCRIPTION
`transform_density!` is the main bottleneck for histogram equalization.
When the number of possible values in the image is modest, it makes
sense to precompute the entire lookup table and then apply it.