### PR TITLE
Fix overflow in contrast-stretching

### DIFF
--- a/src/algorithms/contrast_stretching.jl
+++ b/src/algorithms/contrast_stretching.jl
@@ -66,11 +66,15 @@ ret = adjust_histogram(img, ContrastStretching(t = 0.6, slope = 3))
                                       T₂ <: Union{Real,AbstractGray}}  <: AbstractHistogramAdjustmentAlgorithm
      t::T₁ = 0.5
      slope::T₂ = 1.0
+     ϵ::Union{T₁,Nothing} = nothing
 end
+ContrastStretching(t::T₁, slope::T₂, ϵ::Union{Real,AbstractGray}) where {T₁ <: Union{Real,AbstractGray},
+                                             T₂ <: Union{Real,AbstractGray}} =
+    ContrastStretching{T₁,T₂}(t, slope, T₁(ϵ))
 
 function (f::ContrastStretching)(out::GenericGrayImage, img::GenericGrayImage)
     T = eltype(out)
-    ϵ = eps(T)
+    ϵ = f.ϵ === nothing ? eps(T) : f.ϵ
     out .= img
     map!(out,out) do val
         if isnan(val)
@@ -96,3 +100,4 @@ end
 function contrast_stretch(x, t, s, ϵ)
     return 1 / (1 + (t / (x+ϵ))^s)
 end
+contrast_stretch(x::Union{FixedPoint,AbstractGray{<:FixedPoint}}, t, s, ϵ) = contrast_stretch(float(x), t, s, ϵ)

--- a/test/contrast_stretching.jl
+++ b/test/contrast_stretching.jl
@@ -1,3 +1,7 @@
+using ImageCore
+using ImageContrastAdjustment
+using Test
+
 @testset "Contrast Stretching" begin
 
     for T in (Gray{N0f8}, Gray{N0f16}, Gray{Float32}, Gray{Float64})
@@ -21,6 +25,9 @@
         @test nonzero_before < nonzero_after
         @test nonzero_after == 16
         @test eltype(img) == eltype(ret)
+        if eltype(T) <: FixedPoint
+            @test ret ≈ T.(adjust_histogram(float.(img), ContrastStretching(t = 0.4, slope = 17)))
+        end
 
         #=
         Verify that the function can cope with a NaN value.
@@ -76,4 +83,9 @@
         edges, counts_after = build_histogram(ret, 16, minval = 0, maxval = 1)
         @test sum(counts_after .!= 0) == 2
     end
+
+    # Issue #58
+    img = Gray{N0f8}.([1 0; 0 1])
+    @test adjust_histogram(img, ContrastStretching(t=0.3, slope=0.4)) ==
+          Gray{N0f8}.(adjust_histogram(float.(img), ContrastStretching(t=0.3, slope=0.4, ϵ=eps(N0f8))))
 end


### PR DESCRIPTION
Fixes #58

I needed to add an explicit `ϵ` field to `ContrastStretching` for the test of the explicit case in #58; without it, once you convert to `float` then `eps` gets set to `Gray{Float32}(1.1920929f-7)` rather than `Gray{N0f8}(0.004)` and you get a very different answer.