### PR TITLE
CI: fix macOS arch for Apple Silicon runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -27,16 +27,12 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        arch:
-          - x64
-
     steps:
       - uses: actions/checkout@v6
 
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
 
       - uses: julia-actions/cache@v3
 


### PR DESCRIPTION
`macOS-latest` GitHub runners are now Apple Silicon (arm64). `setup-julia@v3` errors when `arch: x64` is requested on them, so the macOS jobs fail.

This configures the matrix to use the correct native architecture (default per-runner for single-arch matrices; explicit `exclude`/`include` for multi-arch matrices) and bumps `julia-actions/setup-julia` to v3.
